### PR TITLE
Automatically detect latest stable version for rust build

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -41,7 +41,7 @@ If you still can't find it, try searching for the filename online.
 $ git clone https://github.com/Ogeon/rust-on-raspberry-pi.git
 $ cd rust-on-raspberry-pi/docker
 $ docker build \
-    --build-arg RUST_GIT_REF=<branch/tag/commit> \ # defaults to "1.4.0" (stable)
+    --build-arg RUST_GIT_REF=<branch/tag/commit> \ # defaults to latest stable
     --build-arg PI_TOOLS_GIT_REF=<branch/tag/commit> \ # defaults to "master"
     --tag <tag for your docker image> \ # e.g. "rust-nightly-pi-cross"
     .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 ARG PI_TOOLS_GIT_REF=master
-ARG RUST_GIT_REF=1.4.0
+ARG RUST_GIT_REF
 
 # install debian dependencies before we lose root privileges
 RUN apt-get update \
@@ -27,9 +27,11 @@ git reset --hard $PI_TOOLS_GIT_REF;
 COPY bin/gcc-sysroot $HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot
 COPY bin/gcc-sysroot $HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/gcc-sysroot
 
-# install rust
+# install rust (default release: latest stable)
 RUN git clone $URL_GIT_RUST $HOME/rust; \
 cd $HOME/rust; \
+DEFAULT_RUST_GIT_REF=$(git tag --list | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$" | sort -V | tail --lines 1); \
+RUST_GIT_REF=${RUST_GIT_REF:-$DEFAULT_RUST_GIT_REF}; \
 git reset --hard $RUST_GIT_REF; \
 
 export TOOLCHAIN=$TOOLCHAIN_32 && [ $(uname -m) = 'x86_64' ] && export TOOLCHAIN=$TOOLCHAIN_64; \


### PR DESCRIPTION
I updated the git references for the rust repo inside the Dockerfile and it's documentation to 1.5.0 since it has been released as the new stable version...

**Update**: A mechanism was implemented which auto-detects the latest version number of rust stable by using the tags of the rust git repository. This avoids hard coding the version number.
