### PR TITLE
Dockerfile: create user with uid 1000

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,8 +8,12 @@ RUN apt-get update \
 && apt-get install -y git build-essential file wget python libjemalloc1 llvm;
 
 # create & get cross user and drop root privileges
+#
+# On OS X, the user needs to have uid set to 1000
+# in order to access files from the shared volumes.
+# https://medium.com/@brentkearney/docker-on-mac-os-x-9793ac024e94
 RUN groupadd --system cross \
-&& useradd --create-home --system --gid cross cross;
+&& useradd --create-home --system --gid cross --uid 1000 cross;
 USER cross
 ENV HOME=/home/cross \
 URL_GIT_RUST=https://github.com/rust-lang/rust.git \


### PR DESCRIPTION
Fixes permission errors on OS X:

>   The “/Users” folder will be automatically mounted in the VM,
>   and the mount will be owned by a user named “docker” with
>   a uid number of 1000.
> 
>   If you want to access files within the /Users share from your
>   Docker container, then you should do so as a user with uid 1000,
>   otherwise you will likely have permissions errors.

https://medium.com/@brentkearney/docker-on-mac-os-x-9793ac024e94
