### PR TITLE
Dockerfile: optimize pi tools download

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,9 +21,13 @@ ENV TOOLCHAIN_64=$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspb
 TOOLCHAIN_32=$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin
 
 # install pi tools
-RUN git clone $URL_GIT_PI_TOOLS $HOME/pi-tools; \
-cd $HOME/pi-tools; \
-git reset --hard $PI_TOOLS_GIT_REF;
+RUN if [ $PI_TOOLS_GIT_REF = master ]; \
+then git clone --depth 1 $URL_GIT_PI_TOOLS $HOME/pi-tools; \
+else \
+  git clone $URL_GIT_PI_TOOLS $HOME/pi-tools \
+  && cd $HOME/pi-tools \
+  && git reset --hard $PI_TOOLS_GIT_REF; \
+fi
 COPY bin/gcc-sysroot $HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot
 COPY bin/gcc-sysroot $HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/gcc-sysroot
 


### PR DESCRIPTION
If one wants to fetch the HEAD of a git repo, instead of fetching
its whole history they can make a shallow clone which reduces the size
of the downloaded repo and the time needed to do it.

```
$ time git clone https://github.com/raspberrypi/tools.git
Cloning into 'tools'...
remote: Counting objects: 25272, done.
remote: Total 25272 (delta 0), reused 0 (delta 0), pack-reused 25272
Receiving objects: 100% (25272/25272), 591.32 MiB | 1.73 MiB/s, done.
Resolving deltas: 100% (17631/17631), done.
Checking connectivity... done.
Checking out files: 100% (19057/19057), done.
30.63s user 19.34s system 13% cpu 6:15.33 total
```

```
$ time git clone --depth 1 https://github.com/raspberrypi/tools.git
Cloning into 'tools'...
remote: Counting objects: 11007, done.
remote: Compressing objects: 100% (6360/6360), done.
remote: Total 11007 (delta 6071), reused 7365 (delta 4162), pack-reused 0
Receiving objects: 100% (11007/11007), 186.44 MiB | 1.79 MiB/s, done.
Resolving deltas: 100% (6071/6071), done.
Checking connectivity... done.
Checking out files: 100% (19057/19057), done.
13.37s user 8.28s system 14% cpu 2:25.90 total
```
