### PR TITLE
add gcc to apt-get dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG RUST_VERSION=stable
 
 # update system
 RUN apt-get update
-RUN apt-get install -y curl git
+RUN apt-get install -y curl git gcc
 
 # config and set variables
 #


### PR DESCRIPTION
the build fails if no linker is installed.

I do not fully understand why this is needed since the cross-compile-linker should be used. Anyway, with this update I am now able to build my project again.
